### PR TITLE
Avoid copying L2 files

### DIFF
--- a/man/l2_to_dataframe.Rd
+++ b/man/l2_to_dataframe.Rd
@@ -54,5 +54,5 @@ l2_to_dataframe(
 \item{data_compress}{Si TRUE, espera archivos .tar; si FALSE, archivos .nc directos}
 }
 \description{
-Procesa archivos L2 (SeaDAS) y los transforma a L3 y luego a tabla (e.g., parquet)
+Procesa archivos L2 (SeaDAS) y los transforma a L3 y luego a tabla (e.g., parquet). Los archivos L2 y temporales permanecen en \code{dir_input}; solo los resultados finales en parquet o csv se almacenan en \code{dir_output}.
 }


### PR DESCRIPTION
## Summary
- update `l2_to_dataframe` so intermediate nc files remain in `dir_input`
- clarify docs that only final tables are stored in `dir_output`

## Testing
- `R CMD check .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843b9a7b3a88331b163ba8c9c501d15